### PR TITLE
[FEATURE] Provide EXT:my_extension as alias

### DIFF
--- a/tests/unit/addAliases.test.ts
+++ b/tests/unit/addAliases.test.ts
@@ -17,6 +17,10 @@ describe("addAliases", () => {
                 find: "@test_extension",
                 replacement: "/path/to/dummy/extension1/",
             },
+            {
+                find: "EXT:test_extension",
+                replacement: "/path/to/dummy/extension1/",
+            },
         ]);
     });
     test("existing aliases as object", () => {
@@ -37,6 +41,10 @@ describe("addAliases", () => {
             { find: "@existing_find", replacement: "/path/to/replace/with/" },
             {
                 find: "@test_extension",
+                replacement: "/path/to/dummy/extension1/",
+            },
+            {
+                find: "EXT:test_extension",
                 replacement: "/path/to/dummy/extension1/",
             },
         ]);
@@ -80,6 +88,10 @@ describe("addAliases", () => {
                 find: "@test_extension",
                 replacement: "/path/to/dummy/extension1/",
             },
+            {
+                find: "EXT:test_extension",
+                replacement: "/path/to/dummy/extension1/",
+            },
         ]);
     });
     test("no double slashes in added alias paths", () => {
@@ -94,6 +106,10 @@ describe("addAliases", () => {
         ).toEqual([
             {
                 find: "@test_extension",
+                replacement: "/path/to/dummy/extension1/",
+            },
+            {
+                find: "EXT:test_extension",
                 replacement: "/path/to/dummy/extension1/",
             },
         ]);

--- a/tests/unit/outputDebugInformation.test.ts
+++ b/tests/unit/outputDebugInformation.test.ts
@@ -49,7 +49,9 @@ describe("outputDebugInformation", () => {
         expect(logger.info).toHaveBeenNthCalledWith(
             2,
             "The following aliases have been defined: " +
-                colors.green("@test_extension1, @test_extension2"),
+                colors.green(
+                    "@test_extension1, EXT:test_extension1, @test_extension2, EXT:test_extension2",
+                ),
             { timestamp: true },
         );
         expect(logger.info).toHaveBeenNthCalledWith(


### PR DESCRIPTION
In addition to the `@my_extension` alias, now it's also possible to use `EXT:my_extension` in all paths resolved by vite, such as ESM modules or URLs in CSS files.