### PR TITLE
[FEATURE] Register aliases for all available extensions

### DIFF
--- a/src/typo3project.ts
+++ b/src/typo3project.ts
@@ -10,7 +10,7 @@ import type {
 import {
     addAliases,
     addRollupInputs,
-    determineRelevantTypo3Extensions,
+    determineAvailableTypo3Extensions,
     findEntrypointsInExtensions,
     getDefaultIgnoreList,
     initializePluginConfig,
@@ -23,7 +23,7 @@ export default function typo3project(
     const logger = createLogger("info", { prefix: "[plugin-typo3-project]" });
 
     let pluginConfig: PluginConfig<Typo3ProjectContext>;
-    let relevantExtensions: Typo3ExtensionContext[];
+    let availableExtensions: Typo3ExtensionContext[];
     let entrypoints: string[];
 
     return {
@@ -78,21 +78,20 @@ export default function typo3project(
             );
 
             // Extract relevant TYPO3 extensions from composer metadata
-            relevantExtensions = determineRelevantTypo3Extensions(
+            availableExtensions = determineAvailableTypo3Extensions(
                 pluginConfig.composerContext,
-                pluginConfig.entrypointFile,
             );
 
             // Add path alias for each extension
             config.resolve ??= {};
             config.resolve.alias = addAliases(
                 config.resolve.alias,
-                relevantExtensions,
+                availableExtensions,
             );
 
             // Find all vite entrypoints in relevant TYPO3 extensions
             entrypoints = findEntrypointsInExtensions(
-                relevantExtensions,
+                availableExtensions,
                 pluginConfig.entrypointFile,
                 pluginConfig.entrypointIgnorePatterns,
             );
@@ -129,7 +128,7 @@ export default function typo3project(
 
             if (pluginConfig.debug) {
                 outputDebugInformation(
-                    relevantExtensions,
+                    availableExtensions,
                     entrypoints,
                     pluginConfig.composerContext,
                     logger,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,9 +133,8 @@ export function findEntrypointsInExtensions(
     return entrypoints;
 }
 
-export function determineRelevantTypo3Extensions(
+export function determineAvailableTypo3Extensions(
     composerContext: Typo3ProjectContext,
-    entrypointFile: string,
 ): Typo3ExtensionContext[] {
     const composerInstalled = join(
         composerContext.path,
@@ -170,19 +169,17 @@ export function determineRelevantTypo3Extensions(
                 ),
             );
 
-    return installedExtensions.filter((extension) =>
-        fs.existsSync(join(extension.path, entrypointFile)),
-    );
+    return installedExtensions;
 }
 
 export function outputDebugInformation(
-    relevantExtensions: Typo3ExtensionContext[],
+    availableExtensions: Typo3ExtensionContext[],
     entrypoints: string[],
     composerContext: ComposerContext,
     logger: Logger,
 ): void {
-    if (relevantExtensions.length) {
-        const extensionList = relevantExtensions.map(
+    if (availableExtensions.length) {
+        const extensionList = availableExtensions.map(
             (extension) => extension.extensionKey,
         );
         const aliasList = extensionList.reduce(
@@ -191,7 +188,7 @@ export function outputDebugInformation(
             [],
         );
         logger.info(
-            `The following extensions with vite entrypoints have been recognized: ${colors.green(extensionList.join(", "))}`,
+            `The following TYPO3 extensions have been recognized: ${colors.green(extensionList.join(", "))}`,
             { timestamp: true },
         );
         logger.info(

--- a/tests/unit/determineRelevantTypo3Extensions.test.ts
+++ b/tests/unit/determineRelevantTypo3Extensions.test.ts
@@ -1,20 +1,17 @@
 import { describe, test, expect, vi } from "vitest";
-import { determineRelevantTypo3Extensions } from "../../src/utils";
+import { determineAvailableTypo3Extensions } from "../../src/utils";
 
 vi.mock("node:fs");
 
-describe("determineRelevantTypo3Extensions", () => {
-    test("determineRelevantTypo3Extensions", () => {
+describe("determineAvailableTypo3Extensions", () => {
+    test("determineAvailableTypo3Extensions", () => {
         expect(
-            determineRelevantTypo3Extensions(
-                {
-                    type: "project",
-                    path: "/path/to/fixtures/composerProject",
-                    vendorDir: "vendor",
-                    webDir: "public",
-                },
-                "Configuration/ViteEntrypoints.json",
-            ),
+            determineAvailableTypo3Extensions({
+                type: "project",
+                path: "/path/to/fixtures/composerProject",
+                vendorDir: "vendor",
+                webDir: "public",
+            }),
         ).toEqual([
             {
                 type: "typo3-cms-extension",
@@ -31,29 +28,23 @@ describe("determineRelevantTypo3Extensions", () => {
 
     test("no vendor path", () => {
         expect(() => {
-            determineRelevantTypo3Extensions(
-                {
-                    type: "project",
-                    path: "/path/to/fixtures/composerProjectWIthoutVendor",
-                    vendorDir: "vendor",
-                    webDir: "public",
-                },
-                "Configuration/ViteEntrypoints.json",
-            );
+            determineAvailableTypo3Extensions({
+                type: "project",
+                path: "/path/to/fixtures/composerProjectWIthoutVendor",
+                vendorDir: "vendor",
+                webDir: "public",
+            });
         }).toThrow();
     });
 
     test("invalid installed.json", () => {
         expect(() => {
-            determineRelevantTypo3Extensions(
-                {
-                    type: "project",
-                    path: "/path/to/fixtures/composerProjectInvalidVendor",
-                    vendorDir: "vendor",
-                    webDir: "public",
-                },
-                "Configuration/ViteEntrypoints.json",
-            );
+            determineAvailableTypo3Extensions({
+                type: "project",
+                path: "/path/to/fixtures/composerProjectInvalidVendor",
+                vendorDir: "vendor",
+                webDir: "public",
+            });
         }).toThrow();
     });
 });

--- a/tests/unit/outputDebugInformation.test.ts
+++ b/tests/unit/outputDebugInformation.test.ts
@@ -42,7 +42,7 @@ describe("outputDebugInformation", () => {
         expect(logger.info).toHaveBeenCalledTimes(3);
         expect(logger.info).toHaveBeenNthCalledWith(
             1,
-            "The following extensions with vite entrypoints have been recognized: " +
+            "The following TYPO3 extensions have been recognized: " +
                 colors.green("test_extension1, test_extension2"),
             { timestamp: true },
         );


### PR DESCRIPTION
Previously, only extensions that contained a ViteEntrypoints.json were considered.

Resolves #12 