### PR TITLE
[FEATURE] Ability to specify composer packages manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tests/distribution/vite-plugin-typo3*.tgz
 tests/distribution/**/public
 tests/integration/project/public
 tests/integration/project/packages/test_extension/Resources/Public
+tests/integration/uninitializedProject/public
+tests/integration/uninitializedProject/packages/test_extension/Resources/Public

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ You can provide additional configuration to the plugin, for example:
     and `@` are created for all available extension folders. If set to `@`, only `@` aliases
     are created, if set to `EXT`, only `EXT:` aliases are created. If set to `false`, alias
     creation is skipped altogether.
+-   `composerPackagePaths` (array of paths, default `null`): If specified, the automatic
+    discovery of composer packages via `vendor/composer/installed.json` will be skipped. Instead,
+    the specified paths will be scanned for `composer.json` files to be used instead. This can
+    be helpful in CI scenarios where PHP dependencies aren't available in the frontend build
+    step.
 
 ### Fixing CORS issues
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface UserConfig {
     target?: PluginTarget;
     entrypointFile?: string;
     entrypointIgnorePatterns?: string[];
+    composerPackagePaths?: string[];
     debug?: boolean;
     aliases?: AliasConfig;
 }
@@ -10,6 +11,7 @@ export interface PluginConfig<T extends ComposerContext> extends UserConfig {
     target: PluginTarget;
     entrypointFile: string;
     composerContext: T;
+    composerPackagePaths?: string[];
     entrypointIgnorePatterns: string[];
     debug: boolean;
     aliases: AliasConfig;

--- a/src/typo3project.ts
+++ b/src/typo3project.ts
@@ -10,7 +10,8 @@ import type {
 import {
     addAliases,
     addRollupInputs,
-    determineAvailableTypo3Extensions,
+    determineAvailableTypo3ExtensionsFromComposer,
+    determineAvailableTypo3ExtensionsFromPaths,
     findEntrypointsInExtensions,
     getDefaultAllowedOrigins,
     getDefaultIgnoreList,
@@ -90,9 +91,18 @@ export default function typo3project(
             );
 
             // Extract relevant TYPO3 extensions from composer metadata
-            availableExtensions = determineAvailableTypo3Extensions(
-                pluginConfig.composerContext,
-            );
+            if (pluginConfig.composerPackagePaths) {
+                availableExtensions =
+                    determineAvailableTypo3ExtensionsFromPaths(
+                        config.root ?? process.cwd(),
+                        pluginConfig.composerPackagePaths,
+                    );
+            } else {
+                availableExtensions =
+                    determineAvailableTypo3ExtensionsFromComposer(
+                        pluginConfig.composerContext,
+                    );
+            }
 
             // Add path alias for each extension
             config.resolve ??= {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,7 @@ export function findEntrypointsInExtensions(
     return entrypoints;
 }
 
-export function determineAvailableTypo3Extensions(
+export function determineAvailableTypo3ExtensionsFromComposer(
     composerContext: Typo3ProjectContext,
 ): Typo3ExtensionContext[] {
     const composerInstalled = join(
@@ -177,6 +177,30 @@ export function determineAvailableTypo3Extensions(
             );
 
     return installedExtensions;
+}
+
+export function determineAvailableTypo3ExtensionsFromPaths(
+    rootPath: string,
+    composerPackagePaths: string[],
+): Typo3ExtensionContext[] {
+    return composerPackagePaths
+        .map((path: string) => resolve(rootPath, path))
+        .map((absolutePath: string) => {
+            const composerFile = absolutePath + "/composer.json";
+            if (!fs.existsSync(composerFile)) {
+                throw new Error(
+                    `Invalid composer package in "${absolutePath}", composer.json not found.`,
+                );
+            }
+            return createComposerContext(
+                readJsonFile(composerFile),
+                absolutePath,
+            );
+        })
+        .filter(
+            (context: ComposerContext) =>
+                context.type === "typo3-cms-extension",
+        ) as Typo3ExtensionContext[];
 }
 
 export function outputDebugInformation(

--- a/tests/integration/typo3extension.test.ts
+++ b/tests/integration/typo3extension.test.ts
@@ -3,15 +3,28 @@ import { build } from "vite";
 import typo3 from "../../src";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { UserConfig } from "../../src/types";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
-test("vite build works for TYPO3 extension", async () => {
-    const root = join(__dirname, "project/packages/test_extension");
+interface TestCase {
+    projectName: string;
+    pluginConfig: UserConfig;
+}
+
+test.for<TestCase>([
+    { projectName: "project", pluginConfig: {} },
+    { projectName: "uninitializedProject", pluginConfig: {} },
+])("vite build works for TYPO3 extension in $projectName", async (testCase) => {
+    const root = join(
+        __dirname,
+        `${testCase.projectName}/packages/test_extension`,
+    );
     const output = await build({
         root,
-        plugins: [typo3({ target: "extension" })],
+        plugins: [typo3({ target: "extension", ...testCase.pluginConfig })],
         build: {
+            // @ts-expect-error "entry" is specified by plugin, so no need to specify it here
             lib: {
                 cssFileName: "style",
             },
@@ -26,21 +39,23 @@ test("vite build works for TYPO3 extension", async () => {
     expect(esmOutput.output[0].fileName).toMatchInlineSnapshot(
         `"Alt.entry.js"`,
     );
-    expect(esmOutput.output[0].code).toMatchInlineSnapshot(`
-      "//#region tests/integration/project/packages/test_extension/Resources/Private/Alt.entry.ts
-      console.log("Alt.entry.ts");
-      //#endregion
-      "
-    `);
+    expect(esmOutput.output[0].code).toMatch(
+        `
+//#region tests/integration/${testCase.projectName}/packages/test_extension/Resources/Private/Alt.entry.ts
+console.log("Alt.entry.ts");
+//#endregion
+    `.trim(),
+    );
     expect(esmOutput.output[1].fileName).toMatchInlineSnapshot(
         `"Main.entry.js"`,
     );
-    expect(esmOutput.output[1].code).toMatchInlineSnapshot(`
-      "//#region tests/integration/project/packages/test_extension/Resources/Private/JavaScript/Main.ts
-      console.log("Main.ts");
-      //#endregion
-      "
-    `);
+    expect(esmOutput.output[1].code).toMatch(
+        `
+//#region tests/integration/${testCase.projectName}/packages/test_extension/Resources/Private/JavaScript/Main.ts
+console.log("Main.ts");
+//#endregion
+    `.trim(),
+    );
     expect(esmOutput.output[2].fileName).toMatchInlineSnapshot(`"style.css"`);
     expect(esmOutput.output[2].source).toMatchInlineSnapshot(`
       "body{background:red}

--- a/tests/integration/typo3project.test.ts
+++ b/tests/integration/typo3project.test.ts
@@ -3,15 +3,32 @@ import { build } from "vite";
 import typo3 from "../../src";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { RolldownOutput, OutputChunk, OutputAsset } from "rolldown";
+import type { RolldownOutput, OutputChunk, OutputAsset } from "rolldown";
+import { UserConfig } from "../../src/types";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
-test("vite build works for TYPO3 project", async () => {
-    const root = join(__dirname, "project");
+interface TestCase {
+    projectName: string;
+    pluginConfig: UserConfig;
+}
+
+test.for<TestCase>([
+    { projectName: "project", pluginConfig: {} },
+    {
+        projectName: "uninitializedProject",
+        pluginConfig: {
+            composerPackagePaths: [
+                "packages/test_extension/",
+                "vendor/test-vendor/vendor-extension/",
+            ],
+        },
+    },
+])("vite build works for TYPO3 project $projectName", async (testCase) => {
+    const root = join(__dirname, testCase.projectName);
     const output = (await build({
         root,
-        plugins: [typo3()],
+        plugins: [typo3(testCase.pluginConfig)],
     })) as RolldownOutput;
 
     const sortedOutput: (OutputAsset | OutputChunk)[] = output.output.sort(

--- a/tests/integration/uninitializedProject/composer.json
+++ b/tests/integration/uninitializedProject/composer.json
@@ -1,0 +1,3 @@
+{
+    "type": "project"
+}

--- a/tests/integration/uninitializedProject/packages/test_extension/Configuration/ViteEntrypoints.json
+++ b/tests/integration/uninitializedProject/packages/test_extension/Configuration/ViteEntrypoints.json
@@ -1,0 +1,1 @@
+["../Resources/Private/*.entry.ts"]

--- a/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Alt.entry.ts
+++ b/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Alt.entry.ts
@@ -1,0 +1,1 @@
+console.log("Alt.entry.ts");

--- a/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Css/Main.css
+++ b/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Css/Main.css
@@ -1,0 +1,3 @@
+body {
+    background: red;
+}

--- a/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/JavaScript/Main.ts
+++ b/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/JavaScript/Main.ts
@@ -1,0 +1,1 @@
+console.log("Main.ts");

--- a/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Main.entry.ts
+++ b/tests/integration/uninitializedProject/packages/test_extension/Resources/Private/Main.entry.ts
@@ -1,0 +1,2 @@
+import "./Css/Main.css";
+import "./JavaScript/Main.ts";

--- a/tests/integration/uninitializedProject/packages/test_extension/composer.json
+++ b/tests/integration/uninitializedProject/packages/test_extension/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "praetorius/test-extension",
+    "type": "typo3-cms-extension",
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_extension"
+        }
+    }
+}

--- a/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Configuration/ViteEntrypoints.json
+++ b/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Configuration/ViteEntrypoints.json
@@ -1,0 +1,1 @@
+["../Resources/Private/Vendor.entry.ts"]

--- a/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/Css/Vendor.css
+++ b/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/Css/Vendor.css
@@ -1,0 +1,3 @@
+body {
+    background: blue;
+}

--- a/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/JavaScript/Vendor.ts
+++ b/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/JavaScript/Vendor.ts
@@ -1,0 +1,1 @@
+console.log("Vendor.ts");

--- a/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/Vendor.entry.ts
+++ b/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/Resources/Private/Vendor.entry.ts
@@ -1,0 +1,2 @@
+import "./Css/Vendor.css";
+import "./JavaScript/Vendor.ts";

--- a/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/composer.json
+++ b/tests/integration/uninitializedProject/vendor/test-vendor/vendor-extension/composer.json
@@ -1,0 +1,8 @@
+{
+    "type": "typo3-cms-extension",
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "vendor_extension"
+        }
+    }
+}

--- a/tests/unit/determineRelevantTypo3Extensions.test.ts
+++ b/tests/unit/determineRelevantTypo3Extensions.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { determineAvailableTypo3Extensions } from "../../src/utils";
+import {
+    determineAvailableTypo3ExtensionsFromComposer,
+    determineAvailableTypo3ExtensionsFromPaths,
+} from "../../src/utils";
 import { vol } from "memfs";
 import fixtureDirectoryStructure from "./fixtureDirectoryStructure";
 
@@ -10,10 +13,10 @@ beforeEach(() => {
     vol.fromJSON(fixtureDirectoryStructure);
 });
 
-describe("determineAvailableTypo3Extensions", () => {
-    test("determineAvailableTypo3Extensions", () => {
+describe("determineAvailableTypo3ExtensionsFromComposer", () => {
+    test("determineAvailableTypo3ExtensionsFromComposer", () => {
         expect(
-            determineAvailableTypo3Extensions({
+            determineAvailableTypo3ExtensionsFromComposer({
                 type: "project",
                 path: "/path/to/fixtures/composerProject",
                 vendorDir: "vendor",
@@ -35,7 +38,7 @@ describe("determineAvailableTypo3Extensions", () => {
 
     test("no vendor path", () => {
         expect(() => {
-            determineAvailableTypo3Extensions({
+            determineAvailableTypo3ExtensionsFromComposer({
                 type: "project",
                 path: "/path/to/fixtures/composerProjectWIthoutVendor",
                 vendorDir: "vendor",
@@ -46,12 +49,47 @@ describe("determineAvailableTypo3Extensions", () => {
 
     test("invalid installed.json", () => {
         expect(() => {
-            determineAvailableTypo3Extensions({
+            determineAvailableTypo3ExtensionsFromComposer({
                 type: "project",
                 path: "/path/to/fixtures/composerProjectInvalidVendor",
                 vendorDir: "vendor",
                 webDir: "public",
             });
+        }).toThrow();
+    });
+});
+
+describe("determineAvailableTypo3ExtensionsFromPaths", () => {
+    test("determineAvailableTypo3ExtensionsFromPaths", () => {
+        expect(
+            determineAvailableTypo3ExtensionsFromPaths(
+                "/path/to/fixtures/uninitializedComposerProject",
+                [
+                    "packages/composerExtension",
+                    "packages/composerExtension2",
+                    "packages/library",
+                ],
+            ),
+        ).toEqual([
+            {
+                type: "typo3-cms-extension",
+                extensionKey: "composer_extension",
+                path: "/path/to/fixtures/uninitializedComposerProject/packages/composerExtension",
+            },
+            {
+                type: "typo3-cms-extension",
+                extensionKey: "namespace_extension",
+                path: "/path/to/fixtures/uninitializedComposerProject/packages/composerExtension2",
+            },
+        ]);
+    });
+
+    test("invalid composer package", () => {
+        expect(() => {
+            determineAvailableTypo3ExtensionsFromPaths(
+                "/path/to/fixtures/uninitializedComposerProject",
+                ["some/random/folder"],
+            );
         }).toThrow();
     });
 });

--- a/tests/unit/fixtures/uninitializedComposerProject/composer.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/composer.json
@@ -1,0 +1,3 @@
+{
+    "type": "project"
+}

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/Configuration/ViteEntrypoints.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/Configuration/ViteEntrypoints.json
@@ -1,0 +1,1 @@
+["../Resources/Private/Main.entry.js"]

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/Resources/Private/Main.entry.js
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/Resources/Private/Main.entry.js
@@ -1,0 +1,1 @@
+console.log("Main.entry.js");

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/composer.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension/composer.json
@@ -1,0 +1,8 @@
+{
+    "type": "typo3-cms-extension",
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "composer_extension"
+        }
+    }
+}

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/Configuration/ViteEntrypoints.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/Configuration/ViteEntrypoints.json
@@ -1,0 +1,1 @@
+["../Resources/Private/Main.entry.js"]

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/Resources/Private/Main.entry.js
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/Resources/Private/Main.entry.js
@@ -1,0 +1,1 @@
+console.log("Main.entry.js");

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/composer.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/composerExtension2/composer.json
@@ -1,0 +1,8 @@
+{
+    "type": "typo3-cms-extension",
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "namespace_extension"
+        }
+    }
+}

--- a/tests/unit/fixtures/uninitializedComposerProject/packages/library/composer.json
+++ b/tests/unit/fixtures/uninitializedComposerProject/packages/library/composer.json
@@ -1,0 +1,3 @@
+{
+    "type": "library"
+}


### PR DESCRIPTION
A new config option is introduced, which allows to bypass the automatic
package discovery and to supply the package paths manually.

Resolves: #21