### PR TITLE
[!!!][TASK] Don't resolve symlinks in manifest identifiers

### DIFF
--- a/src/typo3extension.ts
+++ b/src/typo3extension.ts
@@ -65,6 +65,7 @@ export default function typo3extension(
 
             // Add path alias for extension
             config.resolve ??= {};
+            config.resolve.preserveSymlinks ??= true;
             config.resolve.alias = addAliases(
                 config.resolve.alias,
                 [extension],

--- a/src/typo3project.ts
+++ b/src/typo3project.ts
@@ -96,6 +96,7 @@ export default function typo3project(
 
             // Add path alias for each extension
             config.resolve ??= {};
+            config.resolve.preserveSymlinks ??= true;
             config.resolve.alias = addAliases(
                 config.resolve.alias,
                 availableExtensions,

--- a/tests/integration/manifest-expected.json
+++ b/tests/integration/manifest-expected.json
@@ -1,14 +1,14 @@
 {
-  "packages/test_extension/Resources/Private/Alt.entry.ts": {
+  "vendor/praetorius/test-extension/Resources/Private/Alt.entry.ts": {
     "file": "assets/Alt.entry-BoPKGVcr.js",
     "name": "Alt.entry",
-    "src": "packages/test_extension/Resources/Private/Alt.entry.ts",
+    "src": "vendor/praetorius/test-extension/Resources/Private/Alt.entry.ts",
     "isEntry": true
   },
-  "packages/test_extension/Resources/Private/Main.entry.ts": {
+  "vendor/praetorius/test-extension/Resources/Private/Main.entry.ts": {
     "file": "assets/Main.entry-49EpidS1.js",
     "name": "Main.entry",
-    "src": "packages/test_extension/Resources/Private/Main.entry.ts",
+    "src": "vendor/praetorius/test-extension/Resources/Private/Main.entry.ts",
     "isEntry": true,
     "css": [
       "assets/Main-VWk4xp3e.css"


### PR DESCRIPTION
This allows `realpath()` code to be removed from the TYPO3 extension.

This is a breaking change because the identifiers will change.
This will require the recent version of the TYPO3 extension,
which will attempt both variants (first without symlink resolving,
second with resolving using `realpath()` as before).

Resolves: #28